### PR TITLE
Make sure Chrome output when the listening line never appears

### DIFF
--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/launch/ChromeLauncher.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/launch/ChromeLauncher.java
@@ -345,11 +345,11 @@ public class ChromeLauncher implements AutoCloseable {
                     chromeOutputBuilder.append(System.lineSeparator());
                   }
                   chromeOutputBuilder.append(line);
+                  chromeOutput.set(chromeOutputBuilder.toString());
                 }
               } catch (Exception e) {
                 LOGGER.error("Failed while waiting for dev tools server.", e);
               } finally {
-                chromeOutput.set(chromeOutputBuilder.toString());
                 closeQuietly(reader);
               }
             });


### PR DESCRIPTION
Make sure Chrome's output is available when the DEVTOOLS_LISTENING_LINE_PATTERN line doesn't appear and stdout doesn't close (eg. due to process closing) within the startup wait time.

Before this change, the ChromeProcessTimeoutException would contain an empty Chrome output string in the case described above.